### PR TITLE
Fix program 3 p4-test1 case's extra next

### DIFF
--- a/p3/test/p4-test1.lcs
+++ b/p3/test/p4-test1.lcs
@@ -14,7 +14,6 @@ check R6 11
 next
 next
 next
-next
 check R5 19
 check R6 10
 


### PR DESCRIPTION
TL;DR: there was an extra `next` that caused the case checking to get out of sync for `p4-test1`. This would then cause failures to pop up in tests run after it when using the `all-tests` script.